### PR TITLE
Change repositories to repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     },
     "main"        : "lib/index.js",
     "keywords"    : ["redis"],
-    "repositories": [{
+    "repository": {
         "type": "git",
         "path": "git://github.com/athoune/node-redis-protocol.git"
-    }],
+    },
     "homepage"    : "http://github.com/athoune/node-redis-protocol",
     "bugs"        : "http://github.com/athoune/node-redis-protocol/issues",
     "licenses"    : [{ "type": "MIT"}],


### PR DESCRIPTION
Fixes the npm install error:

```
npm WARN package.json redis-protocol@0.1.10 'repositories' (plural) Not supported. Please pick one as the 'repository' field
```
